### PR TITLE
Cross-platform support testing and fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,5 @@
 [*.cs]
 csharp_new_line_before_open_brace = none
+[*.csproj]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ Download and run `RiqMenuInstaller.exe` from the [latest release](https://github
 - Install the latest RiqMenu
 - Create the songs folder for you
 
+## Quick Install (Unix)
+
+Download `RiqMenuInstaller-[linux/osx]_x64` from the [latest release](https://github.com/KabirAcharya/RiqMenu/releases) and execute it:
+
+```bash
+% Linux
+./RiqMenuInstaller-linux_x64
+% macOS
+./RiqMenuInstaller-osx_x64
+```
+
+It will automatically:
+- Find your Bits & Bops installation
+- Install the latest BepInEx 5.x
+- Install the latest RiqMenu
+- Create the songs folder for you
+
+Note: you may need to run the game via `run_bepinex.sh`. If you have the game on Steam, you can also set Launch Options in the game properties in Steam launcher to `./run_bepinex.sh %command%`.
+
 ## Manual Installation
 
 - Install [BepInEx 5.x](https://docs.bepinex.dev/articles/user_guide/installation/index.html) into Bits & Bops.

--- a/RiqMenu/RiqMenu.csproj
+++ b/RiqMenu/RiqMenu.csproj
@@ -1,71 +1,74 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>RiqMenu</AssemblyName>
-    <Description> A simple RIQ menu for Bits &amp; Bops. </Description>
+    <Description>A simple RIQ menu for Bits &amp; Bops.</Description>
     <Version>1.5.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Assets\riqmenu_theme" />
+    <EmbeddedResource Include="Assets/riqmenu_theme"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference
-            Include="BepInEx.Analyzers"
-            Version="1.*"
-            PrivateAssets="all"
-        />
-    <PackageReference Include="BepInEx.Core" Version="5.*" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-    <PackageReference
-            Include="UnityEngine.Modules"
-            Version="2021.3.33"
-            IncludeAssets="compile"
-        />
+    <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all"/>
+    <PackageReference Include="BepInEx.Core" Version="5.*"/>
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*"/>
+    <PackageReference Include="UnityEngine.Modules" Version="2021.3.33" IncludeAssets="compile"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
-    <PackageReference
-            Include="Microsoft.NETFramework.ReferenceAssemblies"
-            Version="1.0.3"
-            PrivateAssets="all"
-        />
-  </ItemGroup>
-
-  <ItemGroup>
+  <!-- Windows References -->
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <Reference Include="Assembly-CSharp">
-      <HintPath
-            >F:\Games\Steam\steamapps\common\Bits &amp; Bops Demo\Bits &amp; Bops_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>F:\Games\Steam\steamapps\common\Bits &amp; Bops Demo\Bits &amp; Bops_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Compression">
-      <HintPath
-            >F:\Games\Steam\steamapps\common\Bits &amp; Bops Demo\Bits &amp; Bops_Data\Managed\System.IO.Compression.dll</HintPath>
+      <HintPath>F:\Games\Steam\steamapps\common\Bits &amp; Bops Demo\Bits &amp; Bops_Data\Managed\System.IO.Compression.dll</HintPath>
     </Reference>
     <Reference Include="TempoStudio.Core">
-      <HintPath
-            >F:\Games\Steam\steamapps\common\Bits &amp; Bops Demo\Bits &amp; Bops_Data\Managed\TempoStudio.Core.dll</HintPath>
+      <HintPath>F:\Games\Steam\steamapps\common\Bits &amp; Bops Demo\Bits &amp; Bops_Data\Managed\TempoStudio.Core.dll</HintPath>
     </Reference>
     <Reference Include="Unity.TextMeshPro">
-      <HintPath
-            >F:\Games\Steam\steamapps\common\Bits &amp; Bops Demo\Bits &amp; Bops_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>F:\Games\Steam\steamapps\common\Bits &amp; Bops Demo\Bits &amp; Bops_Data\Managed\Unity.TextMeshPro.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath
-            >F:\Games\Steam\steamapps\common\Bits &amp; Bops Demo\Bits &amp; Bops_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>F:\Games\Steam\steamapps\common\Bits &amp; Bops Demo\Bits &amp; Bops_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
 
+  <!-- Linux/macOS References -->
+  <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
+    <Reference Include="Assembly-CSharp">
+      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Bits &amp; Bops/Bits &amp; Bops_Data/Managed/Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression">
+      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Bits &amp; Bops/Bits &amp; Bops_Data/Managed/System.IO.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="TempoStudio.Core">
+      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Bits &amp; Bops/Bits &amp; Bops_Data/Managed/TempoStudio.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.TextMeshPro">
+      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Bits &amp; Bops/Bits &amp; Bops_Data/Managed/Unity.TextMeshPro.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Bits &amp; Bops/Bits &amp; Bops_Data/Managed/UnityEngine.UI.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <!-- Cross-platform Post-build copy -->
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec
-            Command="copy &quot;$(TargetPath)&quot; &quot;F:\Games\Steam\steamapps\common\Bits &amp; Bops Demo\BepInEx\plugins&quot; /Y"
-        />
-    <Exec
-            Command="copy &quot;$(TargetPath)&quot; &quot;F:\Games\Steam\steamapps\common\Bits &amp; Bops\BepInEx\plugins&quot; /Y"
-        />
+
+    <!-- Windows -->
+    <Exec Condition="'$(OS)' == 'Windows_NT'"
+          Command="copy &quot;$(TargetPath)&quot; &quot;F:\Games\Steam\steamapps\common\Bits &amp; Bops Demo\BepInEx\plugins&quot; /Y"/>
+
+    <!-- Linux -->
+    <Exec Condition="'$(OS)' != 'Windows_NT'"
+          Command="cp &quot;$(TargetPath)&quot; &quot;$HOME/.local/share/Steam/steamapps/common/Bits &amp; Bops/BepInEx/plugins/&quot;"/>
+
   </Target>
 
 </Project>

--- a/RiqMenu/Updater/AutoUpdater.cs
+++ b/RiqMenu/Updater/AutoUpdater.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 using BepInEx.Logging;
 using UnityEngine;
@@ -512,7 +513,10 @@ mv ""{tempPath}"" ""{pluginPath}"" 2>/dev/null
 # Delete this script
 rm -f ""$0""
 ";
-            File.WriteAllText(scriptPath, scriptContent);
+            // Normalize to Unix line endings
+            scriptContent = scriptContent.Replace("\r\n", "\n");
+            
+            File.WriteAllText(scriptPath, scriptContent, new UTF8Encoding(false));
 
             // Make the script executable
             try

--- a/RiqMenuInstaller/Program.cs
+++ b/RiqMenuInstaller/Program.cs
@@ -544,6 +544,7 @@ class Program
 
                 // Print Unix-specific instructions
                 PrintYellow("Note: On Linux/macOS, you may need to run the game via run_bepinex.sh");
+                PrintYellow("You can also set Launch Options in the game properties in Steam launcher to \"./run_bepinex.sh %command%\"");
             }
 
             PrintGreen($"BepInEx {version} installed successfully!");

--- a/RiqMenuInstaller/RiqMenuInstaller.csproj
+++ b/RiqMenuInstaller/RiqMenuInstaller.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishSingleFile>true</PublishSingleFile>

--- a/build/PublishAll.msbuildproj
+++ b/build/PublishAll.msbuildproj
@@ -1,0 +1,48 @@
+<Project DefaultTargets="Publish">
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <OutputDir>$(MSBuildThisFileDirectory)/Releases</OutputDir>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PluginProject Include="../RiqMenu/RiqMenu.csproj"/>
+        <InstallerProject Include="../RiqMenuInstaller/RiqMenuInstaller.csproj"/>
+    </ItemGroup>
+
+    <Target Name="Publish">
+
+        <!-- Build Plugin -->
+        <MSBuild Projects="@(PluginProject)" Targets="Build"
+                 Properties="Configuration=$(Configuration)"/>
+
+        <Copy SourceFiles="..\RiqMenu\bin\$(Configuration)\netstandard2.0\RiqMenu.dll"
+              DestinationFolder="$(OutputDir)"/>
+
+        <!-- Build Windows Installer -->
+        <MSBuild Projects="@(InstallerProject)" Targets="Publish"
+                 Properties="Configuration=$(Configuration);
+                         RuntimeIdentifier=win-x64;
+                         PublishDir=$(OutputDir)"/>
+        <Delete Files="$(OutputDir)/RiqMenuInstaller.pdb"/>
+
+        <!-- Rename Linux Installer -->
+        <MSBuild Projects="@(InstallerProject)" Targets="Publish"
+                 Properties="Configuration=$(Configuration);
+                         RuntimeIdentifier=linux-x64;
+                         PublishDir=$(OutputDir)/temp-linux"/>
+        <Move SourceFiles="$(OutputDir)/temp-linux/RiqMenuInstaller"
+              DestinationFiles="$(OutputDir)/RiqMenuInstaller-linux_x64"/>
+        <RemoveDir Directories="$(OutputDir)/temp-linux"/>
+
+        <!-- Rename macOS Installer -->
+        <MSBuild Projects="@(InstallerProject)" Targets="Publish"
+                 Properties="Configuration=$(Configuration);
+                         RuntimeIdentifier=osx-x64;
+                         PublishDir=$(OutputDir)/temp-osx"/>
+        <Move SourceFiles="$(OutputDir)/temp-osx/RiqMenuInstaller"
+              DestinationFiles="$(OutputDir)/RiqMenuInstaller-osx_x64"/>
+        <RemoveDir Directories="$(OutputDir)/temp-osx"/>
+
+    </Target>
+
+</Project>


### PR DESCRIPTION
#7 

I've done some testing on Ubuntu 24.0.7 and fixed any issues blocking me from building the project or any bugs with installer/auto-updater I found.

- Added cross-platform support for building RiqMenu project on Unix systems.
- Added info about Steam Launch Options trick for setting up BepInEx on Linux/macOS.
- Added an MSBuild project for publishing both RiqMenu and RiqMenuInstaller for all supported platforms.
- Fixed AutoUpdater constantly failing to replace the DLL with the new version after downloading due to line ending issues causing `/bin/bash` to end prematurely.

You can run
```
dotnet publish build/PublishAll.msbuildproj
```
to publish the DLL and all executables to `build/Releases` for convenience.