### PR TITLE
Fixed the UIManager not available error 

### DIFF
--- a/RiqMenu/Core/RiqMenuSystemManager.cs
+++ b/RiqMenu/Core/RiqMenuSystemManager.cs
@@ -38,6 +38,7 @@ namespace RiqMenu.Core
             }
             _instance = this;
             DontDestroyOnLoad(gameObject);
+            InitializeSystems();
         }
 
         public void InitializeSystems() {
@@ -77,6 +78,15 @@ namespace RiqMenu.Core
                 system?.Cleanup();
             }
             _systems.Clear();
+            SongManager = null;
+            AudioManager = null;
+            InputManager = null;
+            UIManager = null;
+            GameplaySystem = null;
+            _isInitialized = false;
+            if (_instance == this) {
+                _instance = null;
+            }
         }
 
         public T GetSystem<T>() where T : class, IRiqMenuSystem {

--- a/RiqMenu/RiqMenu.cs
+++ b/RiqMenu/RiqMenu.cs
@@ -31,7 +31,7 @@ namespace RiqMenu
 
         private static TitleScript titleScript;
 
-        private RiqMenuSystemManager systemManager;
+        private RiqMenuSystemManager systemManager => RiqMenuSystemManager.Instance;
         private SongManager songManager => systemManager?.SongManager;
         private AudioManager audioManager => systemManager?.AudioManager;
         private UIManager uiManager => systemManager?.UIManager;
@@ -52,9 +52,6 @@ namespace RiqMenu
             DontDestroyOnLoad(gameObject);
 
             AutoUpdater.CheckAndUpdate(Logger);
-
-            systemManager = RiqMenuSystemManager.Instance;
-            systemManager.InitializeSystems();
 
             if (songManager != null) {
                 songManager.OnSongsLoaded += OnSongsLoaded;


### PR DESCRIPTION
Error was caused by manager lifecycle issue when BepInEx is configured with `HideManagerGameObject = true`.

Essentially, `RiqMenu` was caching the singleton of `RiqMenuSystemManager` and initializing it only on `Awake`, but later on, that singleton instance was getting destroyed (not exactly sure why, but it only was getting destroyed once in the lifecycle).

Subsequent call to `RiqMenuSystemManager.Instance` afterwards created a new instance, but the game systems were never initialized again on it + `RiqMenu` had `systemManager` set to `null` after Unity cleaned up the references.

The fix here is to basically move the initialization of the subsystems into `RiqMenuSystemManager` itself and make sure the `RiqMenu` always uses a valid reference to the singleton.